### PR TITLE
Fix avr-size "Device: Unknown" message

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,7 +167,7 @@ REMOVE = rm -f
 COPY = cp
 
 HEXSIZE = $(SIZE) --target=$(FORMAT) $(TARGET).hex
-ELFSIZE = $(SIZE) -C $(TARGET).elf
+ELFSIZE = $(SIZE) --mcu=$(MCU) -C $(TARGET).elf
 
 
 


### PR DESCRIPTION
Now avr-size show the target mcu and percent of space used.
